### PR TITLE
Add config management helpers and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # myscript.lua
+
+This repository contains an expanded Roblox exploit UI script (`script.lua`) that provides a multi-tab interface, module manager, autosaving configurations, and utilities such as notifications and a built-in watermark/fps counter.
+
+## Features
+- Acrylic-style UI with tabs, modules, and multiple control types (toggles, sliders, dropdowns, buttons, color pickers, and more).
+- Config system that can save, load, export, and import JSON-based profiles.
+- New helpers for managing saved configs directly from other scripts:
+  - `CLICK_UI.list_configs()` – returns all saved config names.
+  - `CLICK_UI.delete_config(name)` – deletes a specific config file (defaults to `default`).
+  - `CLICK_UI.reset_default_config()` – rebuilds and saves a fresh default config.
+- Utility functions for safe HTTP requests, optional blur, autosave, notifications, and a watermark showing the local player's name and FPS.
+
+## Usage
+Load `script.lua` inside a Roblox exploit environment that exposes functions such as `cloneref`, `writefile`, `readfile`, `isfolder`, `listfiles`, and `delfile`. The script automatically creates and shows the UI, loads the default config if present, and exposes a `CLICK_UI` global for other scripts to reuse the interface and config helpers.


### PR DESCRIPTION
## Summary
- add default config helper plus delete support for saved JSON profiles
- expose new CLICK_UI helpers for listing, deleting, and resetting configs
- document the script features and config management usage in README

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b07bd06a08329b2ab3f44f36714ef)